### PR TITLE
Add use_repo switch to disable the use of the official repository

### DIFF
--- a/cobbler/defaults.yaml
+++ b/cobbler/defaults.yaml
@@ -1,5 +1,6 @@
 cobbler:
   lookup:
+    use_repo: True
     pkgs:
       - dnsmasq
       - rsync

--- a/cobbler/install.sls
+++ b/cobbler/install.sls
@@ -1,5 +1,6 @@
 {% from "cobbler/map.jinja" import cobbler_map with context %}
 
+{% if cobbler_map.lookup.use_repo %}
 {% if grains['os_family'] == 'Debian' %}
 cobbler-repo:
   pkgrepo.managed:
@@ -39,12 +40,15 @@ cobbler-repo:
     - require:
       - file: cobbler-repo-key
 {% endif %}
+{% endif %}
 
 cobbler-deps:
   pkg.installed:
     - pkgs: {{ cobbler_map.lookup['pkgs']|json }}
+{% if cobbler_map.lookup.use_repo %}
     - require:
       - pkgrepo: cobbler-repo
+{% endif %}
 
 {% if cobbler_map.dnsmasq.manage == True %}
 dnsmasq:
@@ -61,7 +65,9 @@ cobbler:
     - refresh: True
     - require:
       - pkg: cobbler-deps
+{% if cobbler_map.lookup.use_repo %}
       - pkgrepo: cobbler-repo
+{% endif %}
 {% if cobbler_map.dnsmasq.manage == True %}
       - pkg: dnsmasq
 {% endif %}


### PR DESCRIPTION
Hi,

I add possibility to disable the use of official repository with one pillar switch. Our use case is to use the EPEL repository (Cobbler is already available in this repo).

The MongoDB formula use the same convention to disable the usage of default repository : https://github.com/saltstack-formulas/mongodb-formula

Regards,

Nicolas