### PR TITLE
Manage loaders for PXE

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ Imports kickstart files from sources based on pillar
 ``cobbler.snippets``
 -----------
 Imports snippet files from sources based on pillar
+
+``cobbler.loaders``
+-----------
+Imports loaders files from cobbler repository + from sources based on pillar

--- a/cobbler/defaults.yaml
+++ b/cobbler/defaults.yaml
@@ -45,6 +45,11 @@ cobbler:
     manage: True
     sources:
       - salt://cobbler/files/snippets
+  loaders:
+    manage: True
+    sync: True
+    sources:
+      - salt://cobbler/files/loaders
   mongodb:
     connection:
       host: localhost

--- a/cobbler/loaders.sls
+++ b/cobbler/loaders.sls
@@ -1,0 +1,19 @@
+{% from "cobbler/map.jinja" import cobbler_map with context %}
+
+{% if 'pxe' in cobbler_map and 'manage' in cobbler_map.loaders and cobbler_map.loaders.manage == True %}
+
+{% if cobbler_map.loaders.sync == True %}
+cobbler get-loaders:
+  cmd.run
+{% endif %}
+
+{% if 'sources' in cobbler_map.loaders %}
+{% for source in cobbler_map.loaders.sources %}
+loaders-from-{{ source }}:
+  file.recurse:
+    - source: {{ source }}
+    - name: {{ cobbler_map.lookup.lib_dir }}/loaders/
+{% endfor %}
+{% endif %}
+
+{% endif %}


### PR DESCRIPTION
Hello,

This PR permits : 
- Sync loaders from Cobbler repository : https://github.com/cobbler/cobbler-loaders
- Deploy our own loaders for PXE. The best use case is to deploy secure boot loaders that are not managed by Cobbler repository : https://cobbler.github.io/blog/2019/10/28/secure-boot.html

Regards,

Nicolas